### PR TITLE
Fixed getopt error handling / added -fPIE

### DIFF
--- a/scripts/x86_toolchain.sh
+++ b/scripts/x86_toolchain.sh
@@ -32,7 +32,7 @@ BREAK="_start"
 RUN=False
 
 # Use getopt to parse command line options. Can be -(short) and/or --(long).
-options=$(getopt -o go:v3qrb: --long gdb,output:,verbose,x86-32,qemu,run,break: -- "$@")
+options=$(getopt -o go:v32qrb: --long gdb,output:,verbose,x86-32,qemu,run,break: -- "$@")
 
 # Set positional parameters to the result from getopt.
 eval set -- "$options"
@@ -53,7 +53,7 @@ while [[ $# -gt 0 ]]; do # while statement is executed if user enters an argumen
                         VERBOSE=True
                         shift # past argument
                         ;;
-                -3|--x86-32) # Getopt only takes one char for short commands (-32 will no longer work).
+                -3|--x86-32) # Getopt only takes one char for short commands (-32 will still work).
                         BITS=False
                         shift # past argument
                         ;;
@@ -73,10 +73,6 @@ while [[ $# -gt 0 ]]; do # while statement is executed if user enters an argumen
                 --)            # Case '--' is always the last arg of getopt args.
                         shift; # past argument 
                         break  # exit the loop 
-                        ;;
-                *)             # Error case
-                        echo "Option $1 is invalid"
-                        shift # past argument
                         ;;
         esac # ends the above case statement
 done # ends the while loop
@@ -111,12 +107,12 @@ fi
 
 if [ "$BITS" == "True" ]; then # if BITS is true, then nasm will compile the file in 64 bit mode
 
-        nasm -f elf64 $1 -o $OUTPUT_FILE.o && echo "" # object file is created
+        nasm -fPIE elf64 $1 -o $OUTPUT_FILE.o && echo "" # object file is created
 
 
 elif [ "$BITS" == "False" ]; then # if BITS is false, then nasm will compile file in 32 bit mode
 
-        nasm -f elf $1 -o $OUTPUT_FILE.o && echo "" # object file is created
+        nasm -fPIE elf $1 -o $OUTPUT_FILE.o && echo "" # object file is created
 
 fi
 


### PR DESCRIPTION
getopt has its own error handling for non-valid options. Therefore, the \*) case could be removed as invalid options were being printed twice. I also added '2' to the -o options in getopt so that a user could still enter -32. This means the 2 doesn't trigger an invalid option message. 3) is still the case for 32 bit and the 2 is just ignored. I also added -fPIE to the nasm section to stop the PIE errors being thrown by gcc. Let me know if/how you would like me to implement an option for fpie. 