### PR TITLE
Changed from NASM to GCC

### DIFF
--- a/Originals_DoNotModify/x86_toolchain.sh
+++ b/Originals_DoNotModify/x86_toolchain.sh
@@ -95,50 +95,29 @@ if [ "$VERBOSE" == "True" ]; then
 	echo "	64 bit mode = $BITS" 
 	echo ""
 
-	echo "NASM started..."
+	echo "GCC started..."
 
 fi
 
 if [ "$BITS" == "True" ]; then
 
-	nasm -f elf64 $1 -o $OUTPUT_FILE.o && echo ""
+	gcc -m64 $1 -o $OUTPUT_FILE && echo ""
 
 
 elif [ "$BITS" == "False" ]; then
 
-	nasm -f elf $1 -o $OUTPUT_FILE.o && echo ""
+	gcc $1 -o $OUTPUT_FILE && echo ""
 
 fi
 
 if [ "$VERBOSE" == "True" ]; then
 
-	echo "NASM finished"
-	echo "Linking ..."
-	
+	echo "GCC finished"	
 fi
 
 if [ "$VERBOSE" == "True" ]; then
 
-	echo "NASM finished"
-	echo "Linking ..."
-fi
-
-if [ "$BITS" == "True" ]; then
-
-	ld -m elf_x86_64 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""
-
-
-elif [ "$BITS" == "False" ]; then
-
-	ld -m elf_i386 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""
-
-fi
-
-
-if [ "$VERBOSE" == "True" ]; then
-
-	echo "Linking finished"
-
+	echo "GCC finished"
 fi
 
 if [ "$QEMU" == "True" ]; then


### PR DESCRIPTION
- Removed if statements handling linker
-  Changed statements being echoed to reference GCC instead of NASM
-  Changed compilation command, included both 64 and 32 bit versions for GCC.