### PR TITLE
Man Pages, Documentation and Pre-install script

### DIFF
--- a/documentation/arm_toolchain
+++ b/documentation/arm_toolchain
@@ -1,0 +1,37 @@
+.\" Manpage for ARM Tool Chain.
+.TH man 8 "March 5, 2024" "1.0" "arm_toolchain man page"
+.SH NAME
+arm_toolchain \- ARM Assembly Tool Chain
+.SH SYNOPSIS
+arm_toolchain.sh  [-p | --port <port number, default 12222>] <assembly filename> [-o | --output <output filename>]
+.SH DESCRIPTION
+ARM Tool Chain is a program for compiling and debugging ARM Assembly Code.
+.SH OPTIONS
+-v | --verbose                Show some information about steps performed.
+
+-g | --gdb                    Run gdb command on executable.
+
+-b | --break <break point>    Add breakpoint after running gdb. Default is _start.
+
+-r | --run                    Run program in gdb automatically. Same as run command inside gdb env.
+
+-q | --qemu                   Run executable in QEMU emulator. This will execute the program.
+
+-p | --port                   Specify a port for communication between QEMU and GDB. Default is 12222.
+
+-64| --x86-64                 Compile for 64bit (x86-64) system.
+
+-o | --output <filename>      Output filename.
+
+.SH EXAMPLE
+
+./arm_toolchain.sh -v -64 <file path/file name> -g -r
+
+This will compile the ARM assembly showing steps performed, compiled for 64bit system, opening in GDB, and running the program in GDB automatically.
+
+.SH SEE ALSO
+man x86_toolchain
+.SH BUGS
+No known bugs.
+.SH AUTHOR
+arm_toolchain: Lubos Kuzma | man page: Emma Gillespie

--- a/documentation/docs.md
+++ b/documentation/docs.md
@@ -1,0 +1,60 @@
+<!--
+Author:         Emma Gillespie
+Date:           2024/03/05
+Description:    This is a documentation file for the Assembly Tool chain tool.
+                This will teach you how to install, run and teach proper use of the tool.
+-->
+
+# Assembly Tool Chain
+This program is a tool chain that will compile assembly code for both X86 and ARM. It was created by Lubos Kuzma (https://www.linkedin.com/in/lubos-kuzma-0719a586)
+
+# Installation
+Using git:
+```
+git clone https://github.com/LubosKuzma/AssemblyToolchains.git
+cd AssemblyToolchains
+chmod +x x86_toolchain.sh
+or
+chmod +x arm_toolchain.sh
+```
+
+Using Zip:
+```
+Click download zip button
+Extract files
+cd AssemblyToolchains
+chmod +x x86_toolchain.sh
+or
+chmod +x arm_toolchain.sh
+```
+
+Before You run the desired toolchain you will need to run the pre-install.sh which will install required files, programs and the man pages.
+From inside AssemblyToolchains folder type:
+```
+cd pre_requirements_installer
+./pre-install.sh
+```
+This may require you to type in your password. This is just to install the needed files.
+
+# Usage
+After you have installed the program and have run the pre-install script we are ready to run the program.
+
+There are some positional arguements which are as follows:
+```
+-v | --verbose                Show some information about steps performed.
+-g | --gdb                    Run gdb command on executable.
+-b | --break <break point>    Add breakpoint after running gdb. Default is _start.
+-r | --run                    Run program in gdb automatically. Same as run command inside gdb env.
+-q | --qemu                   Run executable in QEMU emulator. This will execute the program.
+-64| --x86-64                 Compile for 64bit (x86-64) system.
+-o | --output <filename>      Output filename.
+
+Additionally in ARM:
+-p | --port                   Specify a port for communication between QEMU and GDB. Default is 12222.
+```
+
+For example we can use the X86 Toolchain as follows to debug and compile the x86 assembly:
+```
+./x86_toolchain.sh -v -64 <file path/file name> -g -r
+```
+This will also show steps performed and compile the assembly for 64bit systems.

--- a/documentation/x86_toolchain
+++ b/documentation/x86_toolchain
@@ -1,0 +1,35 @@
+.\" Manpage for x86 Tool Chain.
+.TH man 8 "March 5, 2024" "1.0" "x86_toolchain man page"
+.SH NAME
+x86_toolchain \- X86 Assembly Tool Chain
+.SH SYNOPSIS
+x86_toolchain.sh [ options ] <assembly filename> [-o | --output <output filename>]
+.SH DESCRIPTION
+x86 Tool Chain is a program for compiling and debugging X86 Assembly Code.
+.SH OPTIONS
+-v | --verbose                Show some information about steps performed.
+
+-g | --gdb                    Run gdb command on executable.
+
+-b | --break <break point>    Add breakpoint after running gdb. Default is _start.
+
+-r | --run                    Run program in gdb automatically. Same as run command inside gdb env.
+
+-q | --qemu                   Run executable in QEMU emulator. This will execute the program.
+
+-64| --x86-64                 Compile for 64bit (x86-64) system.
+
+-o | --output <filename>      Output filename.
+
+.SH EXAMPLE
+
+./x86_toolchain.sh -v -64 <file path/file name> -g -r
+
+This will compile the X86 assembly showing steps performed, compiled for 64bit system, opening in GDB, and running the program in GDB automatically.
+
+.SH SEE ALSO
+man arm_toolchain
+.SH BUGS
+No known bugs.
+.SH AUTHOR
+x86_toolchain: Lubos Kuzma | man page: Emma Gillespie

--- a/pre_requirements_installer/pre-install.sh
+++ b/pre_requirements_installer/pre-install.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+# Author:       Emma Gillespie
+# Date:         2024/03/05
+# Description:  A shell script that will install the requirements for the tool chain.
+#               Will also add man pages for the tool chain under man8.
+
+# Might make it do this in a python file instead for ease of use
+
+sudo apt-get install nasm -y
+sudo apt-get install gdb -y
+sudo apt-get install python3 -y
+curl -fsSL https://gef.blah.cat/sh -y # Might have to install gef directly in gdb
+sudo apt-get install qemu-user -y
+
+# For adding the tool chains man pages to man
+sudo cp ../documentation/x86_toolchain /usr/share/man/man8/x86_toolchain.8 -y
+sudo gzip /usr/share/man/man8/x86_toolchain.8
+#man x86_toolchain # For testing purpose only
+
+sudo cp ../documentation/arm_toolchain /usr/share/man/man8/arm_toolchain.8 -y
+sudo gzip /usr/share/man/man8/arm_toolchain.8
+#man arm_toolchain # For testing purpose only


### PR DESCRIPTION
Added man pages for the program under man8. Along with a nice easy to read docs.md file on how to install and use the tool chain. Finally a basic pre-install script, nothing fancy just what the toolchain needs in order to run (tries to install and doesn't check if programs are already installed) and moves the man pages to their respective locations.

The pre-install script is mainly just to move the man pages so the user can run: man <x86 or arm>_toolchain