### PR TITLE
default 64 bit, change nasm and ld to gcc

### DIFF
--- a/Originals_DoNotModify/x86_toolchain.sh
+++ b/Originals_DoNotModify/x86_toolchain.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /run/current-system/sw/bin/bash
 
 # Created by Lubos Kuzma
 # ISS Program, SADT, SAIT
@@ -15,7 +15,7 @@ if [ $# -lt 1 ]; then
 	echo "-b | --break <break point>    Add breakpoint after running gdb. Default is _start."
 	echo "-r | --run                    Run program in gdb automatically. Same as run command inside gdb env."
 	echo "-q | --qemu                   Run executable in QEMU emulator. This will execute the program."
-	echo "-64| --x86-64                 Compile for 64bit (x86-64) system."
+	echo "-32| --x86                    Compile for 32bit (x86) system."
 	echo "-o | --output <filename>      Output filename."
 
 	exit 1
@@ -25,7 +25,7 @@ POSITIONAL_ARGS=()
 GDB=False
 OUTPUT_FILE=""
 VERBOSE=False
-BITS=False
+BITS=True
 QEMU=False
 BREAK="_start"
 RUN=False
@@ -44,8 +44,8 @@ while [[ $# -gt 0 ]]; do
 			VERBOSE=True
 			shift # past argument
 			;;
-		-64|--x84-64)
-			BITS=True
+		-32|--x84)
+			BITS=False
 			shift # past argument
 			;;
 		-q|--qemu)
@@ -101,36 +101,32 @@ fi
 
 if [ "$BITS" == "True" ]; then
 
-	nasm -f elf64 $1 -o $OUTPUT_FILE.o && echo ""
+	 gcc -m64 -g -c $1 -o $OUTPUT_FILE.o && echo ""# gcc apparently does not support nasm syntax, set -masm=intel does nothing
+   #nasm -f elf64 $1 -o $OUTPUT_FILE.o && echo ""
 
 
 elif [ "$BITS" == "False" ]; then
 
-	nasm -f elf $1 -o $OUTPUT_FILE.o && echo ""
+	gcc -m32 -g -c $1 -o $OUTPUT_FILE.o && echo ""# so assembly program must be written the way gcc want
+  #nasm -f elf $1 -o $OUTPUT_FILE.o && echo ""
 
 fi
 
 if [ "$VERBOSE" == "True" ]; then
 
-	echo "NASM finished"
+	echo "GCC to object file finished"
 	echo "Linking ..."
 	
 fi
 
-if [ "$VERBOSE" == "True" ]; then
-
-	echo "NASM finished"
-	echo "Linking ..."
-fi
-
 if [ "$BITS" == "True" ]; then
 
-	ld -m elf_x86_64 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""
+	gcc -g $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""#ld -m elf_x86_64 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""#TODO gcc again
 
 
 elif [ "$BITS" == "False" ]; then
 
-	ld -m elf_i386 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""
+  gcc -g $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""#ld -m elf_i386 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""#TODO gcc to link
 
 fi
 

--- a/Originals_DoNotModify/x86_toolchain.sh
+++ b/Originals_DoNotModify/x86_toolchain.sh
@@ -1,4 +1,4 @@
-#! /run/current-system/sw/bin/bash
+#! /bin/bash
 
 # Created by Lubos Kuzma
 # ISS Program, SADT, SAIT


### PR DESCRIPTION
Trung Le 000920116

default 64 bit, change nasm and ld to gcc

Tested, will not work as expected. Gcc's assembly language is not using the same syntax as nasm, and adding -masm=intel does nothing.