### PR TITLE
Update x86_toolchain.sh: Use GCC & Default to 64-bit

### DIFF
--- a/Originals_DoNotModify/x86_toolchain.sh
+++ b/Originals_DoNotModify/x86_toolchain.sh
@@ -101,7 +101,7 @@ fi
 
 if [ "$BITS" == "True" ]; then
 
-	nasm -f elf64 $1 -o $OUTPUT_FILE.o && echo ""
+	gcc -m64 $1 -o $OUTPUT_FILE.o && echo ""		#replaced 'nasm -f elf64' with gcc -m64
 
 
 elif [ "$BITS" == "False" ]; then
@@ -113,19 +113,19 @@ fi
 if [ "$VERBOSE" == "True" ]; then
 
 	echo "NASM finished"
-	echo "Linking ..."
+	echo "Compiling with GCC ..."				# replaced 'Linking ...'
 	
 fi
 
 if [ "$VERBOSE" == "True" ]; then
 
 	echo "NASM finished"
-	echo "Linking ..."
+	echo "Compiling with GCC..."				# replaced 'Linking ...'
 fi
 
 if [ "$BITS" == "True" ]; then
 
-	ld -m elf_x86_64 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""
+	gcc -m64 $OUTPUT_FILE.o -o $OUTPUT_FILE && echo ""		# replaced the 'ld -m elf_x86_64' with gcc  -m64
 
 
 elif [ "$BITS" == "False" ]; then
@@ -137,7 +137,7 @@ fi
 
 if [ "$VERBOSE" == "True" ]; then
 
-	echo "Linking finished"
+	echo "Compilation finished"		# replaced 'linking' with compilation
 
 fi
 


### PR DESCRIPTION
The script has been adjusted to utilize GCC for assembling the code when the variable $BITS is set to "True". Furthermore, the script now compiles the code for a 64-bit system by default by using GCC's -m64 option during both assembly and linking phase. Also, Echo messages have been updated to reflect the changes, like saying "Compiling with GCC" instead of "Linking" for clarity.